### PR TITLE
Add ability to iterate OffsetLog in reverse (and bidirectionally)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ serde = "1.0.80"
 serde_derive = "1.0.80"
 serde_json = "1.0.33"
 buffered_offset_reader = "0.6"
+bidir_iter = "0.1"
 
 [dev-dependencies]
 criterion = "0.2.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ serde = "1.0.80"
 serde_derive = "1.0.80"
 serde_json = "1.0.33"
 buffered_offset_reader = "0.6"
-bidir_iter = "0.1"
+bidir_iter = "0.2"
 
 [dev-dependencies]
 criterion = "0.2.5"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -107,9 +107,7 @@ fn offset_log_iter(c: &mut Criterion) {
 
     c.bench_function("offset log iter", move |b| {
         b.iter(|| {
-            let log_iter = offset_log.iter().forward();
-
-            let sum: u64 = log_iter
+            let sum: u64 = offset_log.iter().forward()
                 .map(|val| val.data)
                 .map(|val| from_slice(&val).unwrap())
                 .map(|val: Value| match val["value"] {

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -107,7 +107,7 @@ fn offset_log_iter(c: &mut Criterion) {
 
     c.bench_function("offset log iter", move |b| {
         b.iter(|| {
-            let log_iter = offset_log.iter();
+            let log_iter = offset_log.iter().forward();
 
             let sum: u64 = log_iter
                 .map(|val| val.data)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 //!# flumedb
 //!
 //!
+extern crate bidir_iter;
 extern crate buffered_offset_reader;
 extern crate byteorder;
 extern crate bytes;


### PR DESCRIPTION
@pietgeursen Primary motivation here is the ability to iterate through the log in reverse, which is obviously needed. I don't think the bidirectionality is strictly needed, but I decided to implement it that way so I could step forward and backward through the log in my simple cli log viewer.

Example of reverse iteration: `for e in log.iter_at_offset(log.end()).backward() { ... }`