### PR TITLE
Upgrade to latest ssb-multiformats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flumedb"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Piet Geursen <pietgeursen@gmail.com>", "sean billig <sean.billig@gmail.com"]
 edition = "2018"
 license = "AGPL-3.0"
@@ -9,7 +9,6 @@ repository = "https://github.com/sunrise-choir/flumedb-rs"
 documentation = "https://docs.rs/flumedb/"
 readme = "README.md"
 keywords = ["ssb", "scuttlebutt"]
-
 
 [dependencies]
 log = "0.4.8"
@@ -24,7 +23,7 @@ serde_bytes = "0.11.3"
 serde_cbor = "0.10.2"
 buffered_offset_reader = "0.6.0"
 bidir_iter = "0.2.1"
-ssb-multiformats = "0.4.0"
+ssb-multiformats = "0.4.1"
 
 [dev-dependencies]
 criterion = "0.3.0"


### PR DESCRIPTION
I'm currently publishing updated crates for many of the Sunrise repos. This PR updates ssb-multiformats to latest (`0.4.1`) and bumps the crate version to `0.1.5`.